### PR TITLE
Fix for  "Duplicate query conditions: id" error

### DIFF
--- a/mongoforms/fields.py
+++ b/mongoforms/fields.py
@@ -1,3 +1,4 @@
+import copy
 from django import forms
 from django.utils.encoding import smart_unicode
 from pymongo.errors import InvalidId
@@ -33,16 +34,17 @@ class ReferenceField(forms.ChoiceField):
         try:
             oid = ObjectId(value)
             oid = super(ReferenceField, self).clean(oid)
-            obj = self.queryset.get(id=oid)
+            queryset = copy.copy(self.queryset)
+            obj = queryset.get(id=oid)
         except (TypeError, InvalidId, self.queryset._document.DoesNotExist):
             raise forms.ValidationError(self.error_messages['invalid_choice'] % {'value':value})
         return obj
 
 class MongoFormFieldGenerator(object):
     """This class generates Django form-fields for mongoengine-fields."""
-    
+
     def generate(self, field_name, field):
-        """Tries to lookup a matching formfield generator (lowercase 
+        """Tries to lookup a matching formfield generator (lowercase
         field-classname) and raises a NotImplementedError of no generator
         can be found.
         """

--- a/mongoforms/forms.py
+++ b/mongoforms/forms.py
@@ -24,7 +24,7 @@ class MongoFormMetaClass(type):
 
         # add the fields as "our" base fields
         attrs['base_fields'] = SortedDict(fields)
-        
+
         # Meta class available?
         if 'Meta' in attrs and hasattr(attrs['Meta'], 'document') and \
            issubclass(attrs['Meta'].document, BaseDocument):
@@ -32,11 +32,15 @@ class MongoFormMetaClass(type):
 
             formfield_generator = getattr(attrs['Meta'], 'formfield_generator', \
                 MongoFormFieldGenerator)()
+            dict_fields = dict(fields)
 
             # walk through the document fields
             for field_name, field in iter_valid_fields(attrs['Meta']):
                 # add field and override clean method to respect mongoengine-validator
-                doc_fields[field_name] = formfield_generator.generate(field_name, field)
+                if field_name in dict_fields:
+                    doc_fields[field_name] = dict_fields[field_name]
+                else:
+                    doc_fields[field_name] = formfield_generator.generate(field_name, field)
                 doc_fields[field_name].clean = mongoengine_validate_wrapper(
                     doc_fields[field_name].clean, field._validate)
 

--- a/mongoforms/forms.py
+++ b/mongoforms/forms.py
@@ -57,7 +57,7 @@ class MongoForm(forms.BaseForm):
     """Base MongoForm class. Used to create new MongoForms"""
     __metaclass__ = MongoFormMetaClass
 
-    def __init__(self, data=None, auto_id='id_%s', prefix=None, initial=None,
+    def __init__(self, data=None, files=None, auto_id='id_%s', prefix=None, initial=None,
                  error_class=forms.util.ErrorList, label_suffix=':',
                  empty_permitted=False, instance=None):
         """ initialize the form"""
@@ -93,7 +93,7 @@ class MongoForm(forms.BaseForm):
             object_data.update(initial)
 
         self._validate_unique = False
-        super(MongoForm, self).__init__(data, None, auto_id, prefix, object_data, \
+        super(MongoForm, self).__init__(data, files, auto_id, prefix, object_data, \
             error_class, label_suffix, empty_permitted)
 
     def save(self, commit=True):

--- a/mongoforms/utils.py
+++ b/mongoforms/utils.py
@@ -1,9 +1,8 @@
-from django import forms
 from mongoengine.base import ValidationError
 
 def mongoengine_validate_wrapper(old_clean, new_clean):
     """
-    A wrapper function to validate formdata against mongoengine-field
+    A wrapper function to validate formdata against mongoengine-field 
     validator and raise a proper django.forms ValidationError if there
     are any problems.
     """

--- a/mongoforms/utils.py
+++ b/mongoforms/utils.py
@@ -1,3 +1,4 @@
+from django import forms
 from mongoengine.base import ValidationError
 
 def mongoengine_validate_wrapper(old_clean, new_clean):


### PR DESCRIPTION
Hi,

When trying to clean a formset of forms, which contain a ReferenceField, I encountered a  "Duplicate query conditions: id" error. It appears that the QuerySet used in ReferenceField.clean() assigns the result of the get() to itself. When the QuerySet is reused, the error occurs.

I fixed this by making a copy of the QuerySet before modifying it to check value of ReferenceField.
