### PR TITLE
add support for translation( ugettext_lazy )

### DIFF
--- a/mongoforms/fields.py
+++ b/mongoforms/fields.py
@@ -70,6 +70,15 @@ class ListField(forms.MultiValueField):
             widgets=map(attrgetter('widget'), self.fields))
 
 
+class EmbeddedDocumentField(forms.Field):
+
+    def __init__(self, field, field_name, *args, **kwargs):
+        from forms import MongoForm
+        super(EmbeddedDocumentField, self).__init__(*args, **kwargs)
+        meta = type('Meta', (), {'document': field.document_type_obj})
+        self.form = type('%sForm' % field_name, (MongoForm,), {'Meta': meta})
+
+
 class MongoFormFieldGenerator(object):
     """This class generates Django form-fields for mongoengine-fields."""
 
@@ -174,5 +183,12 @@ class MongoFormFieldGenerator(object):
         return ListField(
             field=field.field,  # inner_field = this_field.inner_field
             field_name_base=field_name,
+            required=field.required,
+            initial=field.default)
+
+    def generate_embeddeddocumentfield(self, field_name, field):
+        return EmbeddedDocumentField(
+            field=field,
+            field_name=field_name,
             required=field.required,
             initial=field.default)

--- a/mongoforms/fields.py
+++ b/mongoforms/fields.py
@@ -70,6 +70,28 @@ class ListField(forms.MultiValueField):
             widgets=map(attrgetter('widget'), self.fields))
 
 
+class DictField(forms.MultiValueField):
+    """
+    Dict field for mongo forms.
+    Uses MultiValueField from django.forms module.
+    """
+    key_field_class = forms.CharField
+    key_field_attrs = {'max_length': 255}
+    value_field_class = forms.CharField
+    value_field_attrs = {'max_length': 255}
+
+    def __init__(self, dict_size=2, *args, **kwargs):
+        forms.Field.__init__(self, *args, **kwargs)
+        self.fields = []
+
+        for field_num in range(dict_size):
+            self.fields.append(self.key_field_class(self.key_field_attrs))
+            self.fields.append(self.value_field_class(self.value_field_attrs))
+
+        self.widget = ListWidget(
+            widgets=map(attrgetter('widget'), self.fields))
+
+
 class EmbeddedDocumentField(forms.Field):
 
     def __init__(self, field, field_name, *args, **kwargs):
@@ -87,6 +109,7 @@ class MongoFormFieldGenerator(object):
         field-classname) and raises a NotImplementedError of no generator
         can be found.
         """
+
         if hasattr(self, 'generate_%s' % field.__class__.__name__.lower()):
             return getattr(self, 'generate_%s' % \
                 field.__class__.__name__.lower())(field_name, field)
@@ -183,6 +206,11 @@ class MongoFormFieldGenerator(object):
         return ListField(
             field=field.field,  # inner_field = this_field.inner_field
             field_name_base=field_name,
+            required=field.required,
+            initial=field.default)
+
+    def generate_dictfield(self, field_name, field):
+        return DictField(
             required=field.required,
             initial=field.default)
 

--- a/mongoforms/fields.py
+++ b/mongoforms/fields.py
@@ -1,11 +1,17 @@
+from operator import attrgetter
+
 from django import forms
 from django.utils.encoding import smart_unicode
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
 
+from widgets import ListWidget
+
+
 class ReferenceField(forms.ChoiceField):
     """
-    Reference field for mongo forms. Inspired by `django.forms.models.ModelChoiceField`.
+    Reference field for mongo forms.
+    Inspired by `django.forms.models.ModelChoiceField`.
     """
     def __init__(self, queryset, *aargs, **kwaargs):
         forms.Field.__init__(self, *aargs, **kwaargs)
@@ -38,14 +44,37 @@ class ReferenceField(forms.ChoiceField):
             else:
                 obj = self.queryset.get(id=oid)
         except (TypeError, InvalidId, self.queryset._document.DoesNotExist):
-            raise forms.ValidationError(self.error_messages['invalid_choice'] % {'value':value})
+            raise forms.ValidationError(
+                self.error_messages['invalid_choice'] % {'value': value})
         return obj
+
+
+class ListField(forms.MultiValueField):
+    """
+    List field for mongo forms.
+    Uses MultiValueField from django.forms module.
+    """
+    field_name_separator = '__'
+
+    def __init__(self, field, field_name_base, list_size=2, *args, **kwargs):
+        forms.Field.__init__(self, *args, **kwargs)
+        self.fields = []
+        field_generator = MongoFormFieldGenerator()
+
+        for field_num in range(list_size):
+            field_name = '%s%s%s' % (
+                field_name_base, self.field_name_separator, field_num)
+            self.fields.append(field_generator.generate(field_name, field))
+
+        self.widget = ListWidget(
+            widgets=map(attrgetter('widget'), self.fields))
+
 
 class MongoFormFieldGenerator(object):
     """This class generates Django form-fields for mongoengine-fields."""
-    
+
     def generate(self, field_name, field):
-        """Tries to lookup a matching formfield generator (lowercase 
+        """Tries to lookup a matching formfield generator (lowercase
         field-classname) and raises a NotImplementedError of no generator
         can be found.
         """
@@ -140,3 +169,10 @@ class MongoFormFieldGenerator(object):
 
     def generate_referencefield(self, field_name, field):
         return ReferenceField(field.document_type.objects)
+
+    def generate_listfield(self, field_name, field):
+        return ListField(
+            field=field.field,  # inner_field = this_field.inner_field
+            field_name_base=field_name,
+            required=field.required,
+            initial=field.default)

--- a/mongoforms/widgets.py
+++ b/mongoforms/widgets.py
@@ -1,0 +1,8 @@
+from django.forms import MultiWidget
+
+
+class ListWidget(MultiWidget):
+    """
+    Widget for ListField.
+    Uses MultiWidget from django.forms module.
+    """


### PR DESCRIPTION
mongoform not work with ugettext_lazy for models.field.verbose_name
I add some code for it, this was develop on your develop branch

e.g.

```
from mongoengine import Document, StringField
from django.utils.translation import ugettext_lazy as _


class XXX(Document):
    about = StringField(verbose_name=_('about'))    # the translation for 'about' will not work
```

on forms.py

```
from mongoforms import MongoForm


class XXXForm(MongoForm):
    class Meta:
        document = XXX
```
